### PR TITLE
[Registration-Service] 관리자 화장실 등록 신청 처리 구현

### DIFF
--- a/toilet_registration_service/build.gradle
+++ b/toilet_registration_service/build.gradle
@@ -31,7 +31,9 @@ ext {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.hibernate:hibernate-core:5.6.0.Final'  // Hibernate 추가
+	implementation 'javax.persistence:javax.persistence-api:2.2'  // JPA API 추가
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/toilet_registration_service/build.gradle
+++ b/toilet_registration_service/build.gradle
@@ -32,8 +32,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.hibernate:hibernate-core:5.6.0.Final'  // Hibernate 추가
-	implementation 'javax.persistence:javax.persistence-api:2.2'  // JPA API 추가
+	implementation 'org.hibernate.orm:hibernate-core:6.2.7.Final'  // Hibernate 6.x로 변경
+	implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'  // Jakarta Persistence API로 변경
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/common/Constants.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/common/Constants.java
@@ -7,4 +7,5 @@ import lombok.NoArgsConstructor;
 public final class Constants {
 
 	public final static String USER_ID_HEADER = "X-USER-ID";
+	public final static String ADMIN = "admin";
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/common/Constants.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/common/Constants.java
@@ -8,4 +8,6 @@ public final class Constants {
 
 	public final static String USER_ID_HEADER = "X-USER-ID";
 	public final static String ADMIN = "admin";
+	public final static String APPROVE = "approve";
+	public final static String REJECT = "reject";
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/common/ToiletRegistErrorResult.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/common/ToiletRegistErrorResult.java
@@ -12,7 +12,10 @@ public enum ToiletRegistErrorResult {
 	DUPLICATED_TOILET_REGIST_REGISTER(HttpStatus.BAD_REQUEST, "이미 신청된 화장실 신청입니다."),
 	MISSING_HEADER(HttpStatus.BAD_REQUEST,"사용자 식별값이 헤더에 없습니다."),
 	NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자 권한이 없습니다."),
-	UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Unknown Exception")
+	UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다."),
+	INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 인자가 제공되었습니다."),
+	NO_SUCH_ELEMENT(HttpStatus.NOT_FOUND, "해당 요소를 찾을 수 없습니다."),
+	ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "요청된 엔티티를 찾을 수 없습니다.");
 	;
 
 	private final HttpStatus httpStatus;

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/common/ToiletRegistErrorResult.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/common/ToiletRegistErrorResult.java
@@ -15,6 +15,7 @@ public enum ToiletRegistErrorResult {
 	UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다."),
 	INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 인자가 제공되었습니다."),
 	NO_SUCH_ELEMENT(HttpStatus.NOT_FOUND, "해당 요소를 찾을 수 없습니다."),
+	ALREADY_REGISTERED_TOILET(HttpStatus.BAD_REQUEST, "이미 등록 신청 처리된 화장실입니다."),
 	ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "요청된 엔티티를 찾을 수 없습니다.");
 	;
 

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/common/ToiletRegistErrorResult.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/common/ToiletRegistErrorResult.java
@@ -10,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 public enum ToiletRegistErrorResult {
 
 	DUPLICATED_TOILET_REGIST_REGISTER(HttpStatus.BAD_REQUEST, "이미 신청된 화장실 신청입니다."),
-	UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Unknown Exception"),
+	MISSING_HEADER(HttpStatus.BAD_REQUEST,"사용자 식별값이 헤더에 없습니다."),
+	NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자 권한이 없습니다."),
+	UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Unknown Exception")
 	;
 
 	private final HttpStatus httpStatus;

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistApproveController.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistApproveController.java
@@ -1,0 +1,42 @@
+package org.personal.registration_service.controller;
+
+import static org.personal.registration_service.common.Constants.*;
+
+import org.personal.registration_service.common.ToiletRegistErrorResult;
+import org.personal.registration_service.exception.ToiletRegistException;
+import org.personal.registration_service.request.ToiletRegistApproveRequest;
+import org.personal.registration_service.response.ToiletRegistApproveResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/approves")
+public class ToiletRegistApproveController {
+
+	@PatchMapping
+	public ResponseEntity<ToiletRegistApproveResponse> toiletRegistApprove(
+		@RequestHeader(value = USER_ID_HEADER, required = true) final String userId,
+		@RequestBody @Valid ToiletRegistApproveRequest request) {
+
+		if (userId == null || userId.isEmpty()) {
+			throw new ToiletRegistException(ToiletRegistErrorResult.MISSING_HEADER);
+		}
+
+		// 관리자가 아닌 경우 예외 발생
+		else if (!userId.equals(ADMIN)) {
+			throw new ToiletRegistException(ToiletRegistErrorResult.NOT_ADMIN);
+		}
+
+		return null;
+	}
+}

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistApproveController.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistApproveController.java
@@ -6,6 +6,8 @@ import org.personal.registration_service.common.ToiletRegistErrorResult;
 import org.personal.registration_service.exception.ToiletRegistException;
 import org.personal.registration_service.request.ToiletRegistApproveRequest;
 import org.personal.registration_service.response.ToiletRegistApproveResponse;
+import org.personal.registration_service.service.ToiletRegistApproveService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,6 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/approves")
 public class ToiletRegistApproveController {
 
+	final private ToiletRegistApproveService toiletRegistApproveService;
+
 	@PatchMapping
 	public ResponseEntity<ToiletRegistApproveResponse> toiletRegistApprove(
 		@RequestHeader(value = USER_ID_HEADER, required = true) final String userId,
@@ -37,6 +41,8 @@ public class ToiletRegistApproveController {
 			throw new ToiletRegistException(ToiletRegistErrorResult.NOT_ADMIN);
 		}
 
-		return null;
+		ToiletRegistApproveResponse response = toiletRegistApproveService.updateToiletRegistApprove(request);
+
+		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistController.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistController.java
@@ -35,7 +35,7 @@ public class ToiletRegistController {
 		}
 
 		ToiletRegistResponse response = toiletregistService
-			.addToiletRegist(request.toiletRegistLatitude(), request.toiletRegistLongitude());
+			.addToiletRegist(request);
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistController.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistController.java
@@ -2,6 +2,8 @@ package org.personal.registration_service.controller;
 
 import static org.personal.registration_service.common.Constants.*;
 
+import org.personal.registration_service.common.ToiletRegistErrorResult;
+import org.personal.registration_service.exception.ToiletRegistException;
 import org.personal.registration_service.request.ToiletRegistRequest;
 import org.personal.registration_service.response.ToiletRegistResponse;
 import org.personal.registration_service.service.ToiletRegistService;
@@ -25,11 +27,15 @@ public class ToiletRegistController {
 
 	@PostMapping
 	public ResponseEntity<ToiletRegistResponse> addToiletRegist(
-		@RequestHeader(USER_ID_HEADER) final String userId,
-		@RequestBody @Valid final ToiletRegistRequest toiletRegistRequest){
+		@RequestHeader(value = USER_ID_HEADER, required = true) final String userId,
+		@RequestBody @Valid final ToiletRegistRequest request) {
 
-			ToiletRegistResponse response = toiletregistService
-				.addToiletRegist(toiletRegistRequest.toiletRegistLatitude(), toiletRegistRequest.toiletRegistLongitude());
-			return ResponseEntity.status(HttpStatus.CREATED).body(response);
+		if (userId == null || userId.isEmpty()) {
+			throw new ToiletRegistException(ToiletRegistErrorResult.MISSING_HEADER);
+		}
+
+		ToiletRegistResponse response = toiletregistService
+			.addToiletRegist(request.toiletRegistLatitude(), request.toiletRegistLongitude());
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/domain/ToiletRegist.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/domain/ToiletRegist.java
@@ -3,6 +3,7 @@ package org.personal.registration_service.domain;
 import java.time.LocalDateTime;
 
 import org.personal.registration_service.common.DateParsing;
+import org.personal.registration_service.request.ToiletRegistRequest;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -55,6 +56,7 @@ public class ToiletRegist {
 
 	@Column(name = "toilet_regist_longitude", nullable = false)
 	private Double toiletRegistLongitude;
+
 	//
 	// @Column(name = "toilet_regist_management_agency")
 	// private String toiletRegistManagementAgency;
@@ -124,6 +126,15 @@ public class ToiletRegist {
 	//
 	// @Column(name = "user_email")
 	// private String userEmail;
+
+	@Builder
+	public static ToiletRegist of(ToiletRegistRequest request) {
+		return ToiletRegist.builder()
+			.toiletRegistLatitude(request.toiletRegistLatitude())
+			.toiletRegistLongitude(request.toiletRegistLongitude())
+			.toiletRegistIsApproved(false) // 기본값
+			.build();
+	}
 
 	@PrePersist		//엔티티가 처음 저장될 때 기본값을 설정
 	protected void onCreate() {

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/domain/ToiletRegist.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/domain/ToiletRegist.java
@@ -135,8 +135,8 @@ public class ToiletRegist {
 		}
 	}
 
-	public void update(Boolean isApprived, LocalDateTime confirmedTime) {
-		this.toiletRegistIsApproved = isApprived;
+	public void update(Boolean isApproved, LocalDateTime confirmedTime) {
+		this.toiletRegistIsApproved = isApproved;
 		this.toiletRegistConfirmedDate = DateParsing.LdtToStr(confirmedTime);
 	}
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/domain/ToiletRegist.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/domain/ToiletRegist.java
@@ -134,4 +134,9 @@ public class ToiletRegist {
 			toiletRegistIsApproved = false;
 		}
 	}
+
+	public void update(Boolean isApprived, LocalDateTime confirmedTime) {
+		this.toiletRegistIsApproved = isApprived;
+		this.toiletRegistConfirmedDate = DateParsing.LdtToStr(confirmedTime);
+	}
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/exception/GlobalExceptionHandler.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/exception/GlobalExceptionHandler.java
@@ -62,8 +62,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		return this.makeErrorResponseEntity(ToiletRegistErrorResult.NO_SUCH_ELEMENT, exception.getMessage());
 	}
 
-	@ExceptionHandler({javax.persistence.EntityNotFoundException.class})
-	public ResponseEntity<ErrorResponse> handleEntityNotFoundException(final javax.persistence.EntityNotFoundException exception) {
+	@ExceptionHandler({jakarta.persistence.EntityNotFoundException.class})
+	public ResponseEntity<ErrorResponse> handleEntityNotFoundException(final jakarta.persistence.EntityNotFoundException exception) {
 		log.warn("EntityNotFoundException occur: ", exception);
 		return this.makeErrorResponseEntity(ToiletRegistErrorResult.ENTITY_NOT_FOUND, exception.getMessage());
 	}

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/exception/GlobalExceptionHandler.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/exception/GlobalExceptionHandler.java
@@ -79,6 +79,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 			.body(new ErrorResponse(errorResult.name(), errorResult.getMessage()));
 	}
 
+	private ResponseEntity<ErrorResponse> makeErrorResponseEntity(final ToiletRegistErrorResult errorResult, final String message) {
+		return ResponseEntity.status(errorResult.getHttpStatus())
+			.body(new ErrorResponse(errorResult.name(), errorResult.getMessage()));
+	}
+
 	record ErrorResponse(String code, String message) {
 	}
 

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/exception/GlobalExceptionHandler.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/exception/GlobalExceptionHandler.java
@@ -16,8 +16,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -81,16 +79,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 			.body(new ErrorResponse(errorResult.name(), errorResult.getMessage()));
 	}
 
-	private ResponseEntity<ErrorResponse> makeErrorResponseEntity(final ToiletRegistErrorResult errorResult, final String message) {
-		return ResponseEntity.status(errorResult.getHttpStatus())
-			.body(new ErrorResponse(errorResult.name(), message));
-	}
-
-	@Getter
-	@RequiredArgsConstructor
-	static class ErrorResponse {
-		private final String code;
-		private final String message;
+	record ErrorResponse(String code, String message) {
 	}
 
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/exception/GlobalExceptionHandler.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.personal.registration_service.exception;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 import org.personal.registration_service.common.ToiletRegistErrorResult;
@@ -51,6 +52,24 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		return this.makeErrorResponseEntity(exception.getErrorResult());
 	}
 
+	@ExceptionHandler({IllegalArgumentException.class})
+	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(final IllegalArgumentException exception) {
+		log.warn("IllegalArgumentException occur: ", exception);
+		return this.makeErrorResponseEntity(ToiletRegistErrorResult.INVALID_ARGUMENT, exception.getMessage());
+	}
+
+	@ExceptionHandler({NoSuchElementException.class})
+	public ResponseEntity<ErrorResponse> handleNoSuchElementException(final NoSuchElementException exception) {
+		log.warn("NoSuchElementException occur: ", exception);
+		return this.makeErrorResponseEntity(ToiletRegistErrorResult.NO_SUCH_ELEMENT, exception.getMessage());
+	}
+
+	@ExceptionHandler({javax.persistence.EntityNotFoundException.class})
+	public ResponseEntity<ErrorResponse> handleEntityNotFoundException(final javax.persistence.EntityNotFoundException exception) {
+		log.warn("EntityNotFoundException occur: ", exception);
+		return this.makeErrorResponseEntity(ToiletRegistErrorResult.ENTITY_NOT_FOUND, exception.getMessage());
+	}
+
 	@ExceptionHandler({Exception.class})
 	public ResponseEntity<ErrorResponse> handleException(final Exception exception) {
 		log.warn("Exception occur: ", exception);
@@ -60,6 +79,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	private ResponseEntity<ErrorResponse> makeErrorResponseEntity(final ToiletRegistErrorResult errorResult) {
 		return ResponseEntity.status(errorResult.getHttpStatus())
 			.body(new ErrorResponse(errorResult.name(), errorResult.getMessage()));
+	}
+
+	private ResponseEntity<ErrorResponse> makeErrorResponseEntity(final ToiletRegistErrorResult errorResult, final String message) {
+		return ResponseEntity.status(errorResult.getHttpStatus())
+			.body(new ErrorResponse(errorResult.name(), message));
 	}
 
 	@Getter

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/exception/ToiletRegistException.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/exception/ToiletRegistException.java
@@ -6,8 +6,13 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class ToiletRegistException extends RuntimeException {
 
 	private final ToiletRegistErrorResult errorResult;
+
+	public ToiletRegistException(ToiletRegistErrorResult errorResult) {
+		super(errorResult.getMessage());  // RuntimeException의 메시지 필드를 설정
+		this.errorResult = errorResult;
+	}
+
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/repository/ToiletRegistRepository.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/repository/ToiletRegistRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ToiletRegistRepository extends JpaRepository<ToiletRegist, Long> {
 
-	ToiletRegist findByToiletRegistLatitudeAndToiletRegistLongitude(Double v, Double v1);
+	ToiletRegist findByToiletRegistLatitudeAndToiletRegistLongitude(Double latitude, Double longitude);
 }
 

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/request/ToiletRegistApproveRequest.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/request/ToiletRegistApproveRequest.java
@@ -12,10 +12,7 @@ public record ToiletRegistApproveRequest(
 	Long toiletRegistId,
 
 	@NotNull(message = "승인 여부를 확인해주세요.")
-	Boolean toiletRegistIsApproved,
-
-	@Null(message = "이미 확인된 신청입니다.")
-	String toiletRegistConfirmedDate
+	Boolean toiletRegistIsApproved
 ) {
 
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/request/ToiletRegistApproveRequest.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/request/ToiletRegistApproveRequest.java
@@ -1,0 +1,31 @@
+package org.personal.registration_service.request;
+
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import lombok.Builder;
+
+@Builder
+public record ToiletRegistApproveRequest(
+
+	@NotNull(message = "toiletRegistId는 필수 값입니다.")
+	Long toiletRegistId,
+
+	@NotNull(message = "화장실 등록 신청 날짜는 필수 값입니다.")
+	String toiletRegistDate,
+
+	@NotNull(message = "등록 여부는 필수 값입니다.")
+	@AssertFalse(message = "아직 관리자가 승인하지 않은 신청이어야 합니다.")
+	Boolean toiletRegistIsApproved,
+
+	@Null(message = "관리자가 승인하지 않아 승인 날짜는 항상 NULL이어야 합니다.")
+	String toiletRegistConfirmedDate,
+
+	@NotNull(message = "위도는 필수 값입니다.")
+	Double toiletRegistLatitude,
+
+	@NotNull(message = "경도는 필수 값입니다.")
+	Double toiletRegistLongitude
+) {
+
+}

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/request/ToiletRegistApproveRequest.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/request/ToiletRegistApproveRequest.java
@@ -11,21 +11,11 @@ public record ToiletRegistApproveRequest(
 	@NotNull(message = "toiletRegistId는 필수 값입니다.")
 	Long toiletRegistId,
 
-	@NotNull(message = "화장실 등록 신청 날짜는 필수 값입니다.")
-	String toiletRegistDate,
-
-	@NotNull(message = "등록 여부는 필수 값입니다.")
-	@AssertFalse(message = "아직 관리자가 승인하지 않은 신청이어야 합니다.")
+	@NotNull(message = "승인 여부를 확인해주세요.")
 	Boolean toiletRegistIsApproved,
 
-	@Null(message = "관리자가 승인하지 않아 승인 날짜는 항상 NULL이어야 합니다.")
-	String toiletRegistConfirmedDate,
-
-	@NotNull(message = "위도는 필수 값입니다.")
-	Double toiletRegistLatitude,
-
-	@NotNull(message = "경도는 필수 값입니다.")
-	Double toiletRegistLongitude
+	@Null(message = "이미 확인된 신청입니다.")
+	String toiletRegistConfirmedDate
 ) {
 
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/request/ToiletRegistRequest.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/request/ToiletRegistRequest.java
@@ -9,10 +9,10 @@ public record ToiletRegistRequest(
 	String toiletRegistDate,
 	Boolean toiletRegistIsApproved,
 
-	@NotNull
+	@NotNull(message = "위도는 필수 값입니다.")
 	Double toiletRegistLatitude,
 
-	@NotNull
+	@NotNull(message = "경도는 필수 값입니다.")
 	Double toiletRegistLongitude
 
 ) {

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/response/ToiletRegistApproveResponse.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/response/ToiletRegistApproveResponse.java
@@ -1,0 +1,6 @@
+package org.personal.registration_service.response;
+
+public record ToiletRegistApproveResponse(
+	String message
+) {
+}

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/response/ToiletRegistResponse.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/response/ToiletRegistResponse.java
@@ -1,5 +1,7 @@
 package org.personal.registration_service.response;
 
+import org.personal.registration_service.domain.ToiletRegist;
+
 import lombok.Builder;
 
 @Builder
@@ -37,4 +39,13 @@ public record ToiletRegistResponse(
 	// Integer toiletRegistFemaleChildToiletsNumber,
 	// String userEmail
 ) {
+	public static ToiletRegistResponse of(ToiletRegist savedToiletRegist) {
+		return ToiletRegistResponse.builder()
+			.toiletRegistId(savedToiletRegist.getToiletRegistId())
+			.toiletRegistDate(savedToiletRegist.getToiletRegistDate())
+			.toiletRegistIsApproved(savedToiletRegist.getToiletRegistIsApproved())
+			.toiletRegistLatitude(savedToiletRegist.getToiletRegistLatitude())
+			.toiletRegistLongitude(savedToiletRegist.getToiletRegistLongitude())
+			.build();
+	}
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/service/ToiletRegistApproveService.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/service/ToiletRegistApproveService.java
@@ -1,0 +1,8 @@
+package org.personal.registration_service.service;
+
+import org.personal.registration_service.request.ToiletRegistApproveRequest;
+import org.personal.registration_service.response.ToiletRegistApproveResponse;
+
+public interface ToiletRegistApproveService {
+	ToiletRegistApproveResponse updateToiletRegistApprove(ToiletRegistApproveRequest request);
+}

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/service/ToiletRegistService.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/service/ToiletRegistService.java
@@ -1,7 +1,8 @@
 package org.personal.registration_service.service;
 
+import org.personal.registration_service.request.ToiletRegistRequest;
 import org.personal.registration_service.response.ToiletRegistResponse;
 
 public interface ToiletRegistService {
-	ToiletRegistResponse addToiletRegist(final Double latitude, final Double Longitude);
+	ToiletRegistResponse addToiletRegist(ToiletRegistRequest toiletRegistRequest);
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImpl.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImpl.java
@@ -1,0 +1,28 @@
+package org.personal.registration_service.service.impl;
+
+import org.personal.registration_service.common.ToiletRegistErrorResult;
+import org.personal.registration_service.domain.ToiletRegist;
+import org.personal.registration_service.exception.ToiletRegistException;
+import org.personal.registration_service.repository.ToiletRegistRepository;
+import org.personal.registration_service.request.ToiletRegistApproveRequest;
+import org.personal.registration_service.response.ToiletRegistApproveResponse;
+import org.personal.registration_service.service.ToiletRegistApproveService;
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ToiletRegistApproveServiceImpl implements ToiletRegistApproveService {
+
+	final ToiletRegistRepository toiletRegistRepository;
+
+	@Override
+	public ToiletRegistApproveResponse updateToiletRegistApprove(ToiletRegistApproveRequest request) {
+		final ToiletRegist toiletRegist = toiletRegistRepository.findById(request.toiletRegistId())
+		.orElseThrow(() -> new ToiletRegistException(ToiletRegistErrorResult.ENTITY_NOT_FOUND));
+
+		return null;
+	}
+}

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImpl.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImpl.java
@@ -1,5 +1,9 @@
 package org.personal.registration_service.service.impl;
 
+import static org.personal.registration_service.common.Constants.*;
+
+import java.time.LocalDateTime;
+
 import org.personal.registration_service.common.ToiletRegistErrorResult;
 import org.personal.registration_service.domain.ToiletRegist;
 import org.personal.registration_service.exception.ToiletRegistException;
@@ -9,7 +13,6 @@ import org.personal.registration_service.response.ToiletRegistApproveResponse;
 import org.personal.registration_service.service.ToiletRegistApproveService;
 import org.springframework.stereotype.Service;
 
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -23,6 +26,11 @@ public class ToiletRegistApproveServiceImpl implements ToiletRegistApproveServic
 		final ToiletRegist toiletRegist = toiletRegistRepository.findById(request.toiletRegistId())
 		.orElseThrow(() -> new ToiletRegistException(ToiletRegistErrorResult.ENTITY_NOT_FOUND));
 
-		return null;
+		toiletRegist.update(request.toiletRegistIsApproved(), LocalDateTime.now());
+		toiletRegistRepository.save(toiletRegist);
+
+		String status = request.toiletRegistIsApproved() ? APPROVE : REJECT;
+
+		return new ToiletRegistApproveResponse(status);
 	}
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImpl.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImpl.java
@@ -26,6 +26,11 @@ public class ToiletRegistApproveServiceImpl implements ToiletRegistApproveServic
 		final ToiletRegist toiletRegist = toiletRegistRepository.findById(request.toiletRegistId())
 		.orElseThrow(() -> new ToiletRegistException(ToiletRegistErrorResult.ENTITY_NOT_FOUND));
 
+		// 이미 등록 처리된 화장실인지 확인
+		if (toiletRegist.getToiletRegistConfirmedDate() != null) {
+			throw new ToiletRegistException(ToiletRegistErrorResult.ALREADY_REGISTERED_TOILET);
+		}
+
 		toiletRegist.update(request.toiletRegistIsApproved(), LocalDateTime.now());
 		toiletRegistRepository.save(toiletRegist);
 

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistServiceImpl.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistServiceImpl.java
@@ -17,24 +17,20 @@ public class ToiletRegistServiceImpl implements ToiletRegistService {
 
 	private final ToiletRegistRepository toiletRegistRepository;
 
-	public ToiletRegistResponse addToiletRegist(final Double latitude, final Double Longitude){
+	public ToiletRegistResponse addToiletRegist(final Double latitude, final Double longitude){
 
-		final ToiletRegist result = toiletRegistRepository.findByToiletRegistLatitudeAndToiletRegistLongitude(latitude, Longitude);
+		final ToiletRegist result = toiletRegistRepository.findByToiletRegistLatitudeAndToiletRegistLongitude(latitude, longitude);
 		if(result != null){
 			throw new ToiletRegistException(ToiletRegistErrorResult.DUPLICATED_TOILET_REGIST_REGISTER);
 		}
 
 		final ToiletRegist toiletRegist = ToiletRegist.builder()
-			.toiletRegistLatitude(37.123456)
-			.toiletRegistLongitude(127.123456)
+			.toiletRegistLatitude(latitude)
+			.toiletRegistLongitude(longitude)
 			.build();
 
 		final ToiletRegist savedToiletRegist = toiletRegistRepository.save(toiletRegist);
 
-		return ToiletRegistResponse.builder()
-			.toiletRegistId(savedToiletRegist.getToiletRegistId())
-			.toiletRegistLatitude(savedToiletRegist.getToiletRegistLatitude())
-			.toiletRegistLongitude(savedToiletRegist.getToiletRegistLongitude())
-			.build();
+		return ToiletRegistResponse.of(savedToiletRegist);
 	}
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistServiceImpl.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistServiceImpl.java
@@ -4,6 +4,7 @@ import org.personal.registration_service.common.ToiletRegistErrorResult;
 import org.personal.registration_service.domain.ToiletRegist;
 import org.personal.registration_service.exception.ToiletRegistException;
 import org.personal.registration_service.repository.ToiletRegistRepository;
+import org.personal.registration_service.request.ToiletRegistRequest;
 import org.personal.registration_service.response.ToiletRegistResponse;
 import org.personal.registration_service.service.ToiletRegistService;
 import org.springframework.stereotype.Service;
@@ -16,18 +17,16 @@ public class ToiletRegistServiceImpl implements ToiletRegistService {
 
 	private final ToiletRegistRepository toiletRegistRepository;
 
-	public ToiletRegistResponse addToiletRegist(final Double latitude, final Double longitude){
+	public ToiletRegistResponse addToiletRegist(ToiletRegistRequest request){
 
-		final ToiletRegist result = toiletRegistRepository.findByToiletRegistLatitudeAndToiletRegistLongitude(latitude, longitude);
+		final ToiletRegist result = toiletRegistRepository.findByToiletRegistLatitudeAndToiletRegistLongitude(
+			request.toiletRegistLatitude(), request.toiletRegistLongitude());
 
 		if(result != null){
 			throw new ToiletRegistException(ToiletRegistErrorResult.DUPLICATED_TOILET_REGIST_REGISTER);
 		}
 
-		final ToiletRegist toiletRegist = ToiletRegist.builder()
-			.toiletRegistLatitude(latitude)
-			.toiletRegistLongitude(longitude)
-			.build();
+		final ToiletRegist toiletRegist = ToiletRegist.of(request);
 
 		final ToiletRegist savedToiletRegist = toiletRegistRepository.save(toiletRegist);
 

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistServiceImpl.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistServiceImpl.java
@@ -4,7 +4,6 @@ import org.personal.registration_service.common.ToiletRegistErrorResult;
 import org.personal.registration_service.domain.ToiletRegist;
 import org.personal.registration_service.exception.ToiletRegistException;
 import org.personal.registration_service.repository.ToiletRegistRepository;
-import org.personal.registration_service.request.ToiletRegistRequest;
 import org.personal.registration_service.response.ToiletRegistResponse;
 import org.personal.registration_service.service.ToiletRegistService;
 import org.springframework.stereotype.Service;
@@ -20,6 +19,7 @@ public class ToiletRegistServiceImpl implements ToiletRegistService {
 	public ToiletRegistResponse addToiletRegist(final Double latitude, final Double longitude){
 
 		final ToiletRegist result = toiletRegistRepository.findByToiletRegistLatitudeAndToiletRegistLongitude(latitude, longitude);
+
 		if(result != null){
 			throw new ToiletRegistException(ToiletRegistErrorResult.DUPLICATED_TOILET_REGIST_REGISTER);
 		}

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
@@ -1,0 +1,126 @@
+package org.personal.registration_service.controller;
+
+import static org.personal.registration_service.common.Constants.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.personal.registration_service.common.DateParsing;
+import org.personal.registration_service.exception.GlobalExceptionHandler;
+import org.personal.registration_service.request.ToiletRegistApproveRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+
+@ExtendWith(MockitoExtension.class)
+class ToiletRegistApproveControllerTests {
+
+	@InjectMocks
+	private ToiletRegistApproveController target;
+
+	private final Double lat = 37.123456;
+	private final Double lng = 127.123456;
+
+	private ObjectMapper objectMapper;
+	private MockMvc mockMvc;
+	private Gson gson;
+
+	@BeforeEach
+	public void init() {
+		objectMapper = new ObjectMapper();
+		gson = new Gson();
+		mockMvc = MockMvcBuilders.standaloneSetup(target).setControllerAdvice(new GlobalExceptionHandler()).build();
+	}
+
+	@Test
+	public void 화장실등록신청등록실패_사용자식별값이헤더에없음() throws Exception {
+		// given
+		final String url = "/approves";
+
+		// when
+		final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch(url)
+			.content(gson.toJson(toiletRegistRequest(lat, lng)))
+			.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	public void 화장실등록신청확인실패_관리자가아님() throws Exception {
+		// given
+		final String url = "/approves";
+
+		// when
+		final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch(url)
+			.header(USER_ID_HEADER, "12345")
+			.content(gson.toJson(toiletRegistRequest(lat, lng)))
+			.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions.andExpect(status().isForbidden());
+	}
+
+	@Test
+	public void 화장실등록신청확인성공_관리자확인() throws Exception {
+		// given
+		final String url = "/approves";
+
+		// when
+		final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch(url)
+			.header(USER_ID_HEADER, "admin")
+			.content(gson.toJson(toiletRegistRequest(lat, lng)))
+			.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions.andExpect(status().isOk());
+	}
+
+	@Test
+	public void 화장실등록신청실패_이미승인된신청() throws Exception {
+		// given
+		final String url = "/approves";
+
+		// when
+		final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch(url)
+			.header(USER_ID_HEADER, "admin")
+			.content(gson.toJson(toiletRegistApprovedRequest(lat, lng)))
+			.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions.andExpect(status().isBadRequest());
+	}
+
+	private ToiletRegistApproveRequest toiletRegistRequest(final Double lat, final Double lng) {
+		return ToiletRegistApproveRequest.builder()
+			.toiletRegistId(1L)
+			.toiletRegistIsApproved(false)
+			.toiletRegistDate(DateParsing.LdtToStr(LocalDateTime.now()))
+			.toiletRegistConfirmedDate(null)
+			.toiletRegistLatitude(lat)
+			.toiletRegistLongitude(lng)
+			.build();
+	}
+
+	private ToiletRegistApproveRequest toiletRegistApprovedRequest(final Double lat, final Double lng) {
+		return ToiletRegistApproveRequest.builder()
+			.toiletRegistId(1L)
+			.toiletRegistIsApproved(true)
+			.toiletRegistDate(DateParsing.LdtToStr(LocalDateTime.now()))
+			.toiletRegistConfirmedDate(DateParsing.LdtToStr(LocalDateTime.now()))
+			.toiletRegistLatitude(lat)
+			.toiletRegistLongitude(lng)
+			.build();
+	}
+
+}

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
@@ -90,7 +90,6 @@ class ToiletRegistApproveControllerTests {
 		return ToiletRegistApproveRequest.builder()
 			.toiletRegistId(1L)
 			.toiletRegistIsApproved(false)
-			.toiletRegistConfirmedDate(null)
 			.build();
 	}
 

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
@@ -3,14 +3,11 @@ package org.personal.registration_service.controller;
 import static org.personal.registration_service.common.Constants.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.time.LocalDateTime;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.personal.registration_service.common.DateParsing;
 import org.personal.registration_service.exception.GlobalExceptionHandler;
 import org.personal.registration_service.request.ToiletRegistApproveRequest;
 import org.springframework.http.MediaType;
@@ -27,9 +24,6 @@ class ToiletRegistApproveControllerTests {
 
 	@InjectMocks
 	private ToiletRegistApproveController target;
-
-	private final Double lat = 37.123456;
-	private final Double lng = 127.123456;
 
 	private ObjectMapper objectMapper;
 	private MockMvc mockMvc;
@@ -49,7 +43,7 @@ class ToiletRegistApproveControllerTests {
 
 		// when
 		final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch(url)
-			.content(gson.toJson(toiletRegistRequest(lat, lng)))
+			.content(gson.toJson(toiletRegistRequest()))
 			.contentType(MediaType.APPLICATION_JSON));
 
 		// then
@@ -64,7 +58,7 @@ class ToiletRegistApproveControllerTests {
 		// when
 		final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch(url)
 			.header(USER_ID_HEADER, "12345")
-			.content(gson.toJson(toiletRegistRequest(lat, lng)))
+			.content(gson.toJson(toiletRegistRequest()))
 			.contentType(MediaType.APPLICATION_JSON));
 
 		// then
@@ -79,47 +73,18 @@ class ToiletRegistApproveControllerTests {
 		// when
 		final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch(url)
 			.header(USER_ID_HEADER, "admin")
-			.content(gson.toJson(toiletRegistRequest(lat, lng)))
+			.content(gson.toJson(toiletRegistRequest()))
 			.contentType(MediaType.APPLICATION_JSON));
 
 		// then
 		resultActions.andExpect(status().isOk());
 	}
 
-	@Test
-	public void 화장실등록신청실패_이미승인된신청() throws Exception {
-		// given
-		final String url = "/approves";
-
-		// when
-		final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch(url)
-			.header(USER_ID_HEADER, "admin")
-			.content(gson.toJson(toiletRegistApprovedRequest(lat, lng)))
-			.contentType(MediaType.APPLICATION_JSON));
-
-		// then
-		resultActions.andExpect(status().isBadRequest());
-	}
-
-	private ToiletRegistApproveRequest toiletRegistRequest(final Double lat, final Double lng) {
+	private ToiletRegistApproveRequest toiletRegistRequest() {
 		return ToiletRegistApproveRequest.builder()
 			.toiletRegistId(1L)
 			.toiletRegistIsApproved(false)
-			.toiletRegistDate(DateParsing.LdtToStr(LocalDateTime.now()))
 			.toiletRegistConfirmedDate(null)
-			.toiletRegistLatitude(lat)
-			.toiletRegistLongitude(lng)
-			.build();
-	}
-
-	private ToiletRegistApproveRequest toiletRegistApprovedRequest(final Double lat, final Double lng) {
-		return ToiletRegistApproveRequest.builder()
-			.toiletRegistId(1L)
-			.toiletRegistIsApproved(true)
-			.toiletRegistDate(DateParsing.LdtToStr(LocalDateTime.now()))
-			.toiletRegistConfirmedDate(DateParsing.LdtToStr(LocalDateTime.now()))
-			.toiletRegistLatitude(lat)
-			.toiletRegistLongitude(lng)
 			.build();
 	}
 

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
@@ -48,6 +48,7 @@ class ToiletRegistApproveControllerTests {
 
 		// when
 		final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch(url)
+			.header(USER_ID_HEADER, "")
 			.content(gson.toJson(toiletRegistRequest()))
 			.contentType(MediaType.APPLICATION_JSON));
 

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.personal.registration_service.exception.GlobalExceptionHandler;
 import org.personal.registration_service.request.ToiletRegistApproveRequest;
+import org.personal.registration_service.service.impl.ToiletRegistApproveServiceImpl;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -24,6 +26,9 @@ class ToiletRegistApproveControllerTests {
 
 	@InjectMocks
 	private ToiletRegistApproveController target;
+
+	@Mock
+	private ToiletRegistApproveServiceImpl toiletRegistApproveService;
 
 	private ObjectMapper objectMapper;
 	private MockMvc mockMvc;

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistControllerTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistControllerTests.java
@@ -103,7 +103,7 @@ class ToiletRegistControllerTests {
 		final String url = "/toiletregists";
 		doThrow(new ToiletRegistException(ToiletRegistErrorResult.DUPLICATED_TOILET_REGIST_REGISTER))
 			.when(toiletRegistService)
-			.addToiletRegist(lat, lng);
+			.addToiletRegist(toiletRegistRequest(lat, lng));
 
 		// when
 		final ResultActions resultActions = mockMvc.perform(
@@ -130,7 +130,7 @@ class ToiletRegistControllerTests {
 			.toiletRegistLongitude(lng)
 			.build();
 
-		doReturn(toiletRegistResponse).when(toiletRegistService).addToiletRegist(lat, lng);
+		doReturn(toiletRegistResponse).when(toiletRegistService).addToiletRegist(toiletRegistRequest(lat, lng));
 
 		// when
 		final ResultActions resultActions = mockMvc.perform(

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistControllerTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistControllerTests.java
@@ -70,6 +70,7 @@ class ToiletRegistControllerTests {
 		// when
 		final ResultActions resultActions = mockMvc.perform(
 			MockMvcRequestBuilders.post(url)
+				.header(USER_ID_HEADER, "")
 				.content(gson.toJson(toiletRegistRequest(lat, lng)))
 				.contentType(MediaType.APPLICATION_JSON)
 		);
@@ -153,6 +154,7 @@ class ToiletRegistControllerTests {
 		assertThat(response.toiletRegistLatitude()).isEqualTo(lat);
 		assertThat(response.toiletRegistLongitude()).isEqualTo(lng);
 	}
+
 	private ToiletRegistRequest toiletRegistRequest(final Double lat, final Double lng){
 		return ToiletRegistRequest.builder()
 			.toiletRegistLatitude(lat)

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
@@ -1,0 +1,48 @@
+package org.personal.registration_service.service.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.personal.registration_service.common.ToiletRegistErrorResult;
+import org.personal.registration_service.exception.ToiletRegistException;
+import org.personal.registration_service.repository.ToiletRegistRepository;
+import org.personal.registration_service.request.ToiletRegistApproveRequest;
+
+@ExtendWith(MockitoExtension.class)
+class ToiletRegistApproveServiceImplTests {
+
+	@InjectMocks
+	private ToiletRegistApproveServiceImpl target;
+
+	@Mock
+	private ToiletRegistRepository toiletRegistRepository;
+
+	@Test
+	public void 화장실등록실패_등록된화장실없음() {
+		// given
+		when(toiletRegistRepository.findById(1L)).thenReturn(Optional.empty());
+
+		// when
+		final ToiletRegistException result = assertThrows(ToiletRegistException.class, () -> target.updateToiletRegistApprove(request()));
+
+		// then
+		assertThat(result.getErrorResult()).isEqualTo(ToiletRegistErrorResult.ENTITY_NOT_FOUND);
+
+	}
+
+	private ToiletRegistApproveRequest request(){
+		return ToiletRegistApproveRequest.builder()
+			.toiletRegistId(1L)
+			.toiletRegistIsApproved(false)
+			.build();
+	}
+
+}

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
@@ -3,7 +3,9 @@ package org.personal.registration_service.service.impl;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.personal.registration_service.common.Constants.*;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -11,10 +13,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.personal.registration_service.common.DateParsing;
 import org.personal.registration_service.common.ToiletRegistErrorResult;
+import org.personal.registration_service.domain.ToiletRegist;
 import org.personal.registration_service.exception.ToiletRegistException;
 import org.personal.registration_service.repository.ToiletRegistRepository;
 import org.personal.registration_service.request.ToiletRegistApproveRequest;
+import org.personal.registration_service.response.ToiletRegistApproveResponse;
 
 @ExtendWith(MockitoExtension.class)
 class ToiletRegistApproveServiceImplTests {
@@ -31,17 +36,55 @@ class ToiletRegistApproveServiceImplTests {
 		when(toiletRegistRepository.findById(1L)).thenReturn(Optional.empty());
 
 		// when
-		final ToiletRegistException result = assertThrows(ToiletRegistException.class, () -> target.updateToiletRegistApprove(request()));
+		final ToiletRegistException result = assertThrows(ToiletRegistException.class, () -> target.updateToiletRegistApprove(requestReject()));
 
 		// then
 		assertThat(result.getErrorResult()).isEqualTo(ToiletRegistErrorResult.ENTITY_NOT_FOUND);
-
 	}
 
-	private ToiletRegistApproveRequest request(){
+	@Test
+	public void 화장실등록성공_반려됨(){
+		// given
+		ToiletRegist mockToiletRegist = mock(ToiletRegist.class);
+		doReturn(Optional.of(mockToiletRegist)).when(toiletRegistRepository).findById(1L);
+		doReturn(mockToiletRegist).when(toiletRegistRepository).save(any(ToiletRegist.class));
+
+		// when
+		final ToiletRegistApproveResponse result = target.updateToiletRegistApprove(requestReject());
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.message()).isEqualTo(REJECT);
+	}
+
+	@Test
+	public void 화장실등록성공_승인됨(){
+		// given
+		ToiletRegist mockToiletRegist = mock(ToiletRegist.class);
+		doReturn(Optional.of(mockToiletRegist)).when(toiletRegistRepository).findById(1L);
+		doReturn(mockToiletRegist).when(toiletRegistRepository).save(any(ToiletRegist.class));
+
+		// when
+		final ToiletRegistApproveResponse result = target.updateToiletRegistApprove(requestApprove());
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.message()).isEqualTo(APPROVE);
+	}
+
+	private ToiletRegistApproveRequest requestReject(){
 		return ToiletRegistApproveRequest.builder()
 			.toiletRegistId(1L)
 			.toiletRegistIsApproved(false)
+			.toiletRegistConfirmedDate(DateParsing.LdtToStr(LocalDateTime.now()))
+			.build();
+	}
+
+	private ToiletRegistApproveRequest requestApprove(){
+		return ToiletRegistApproveRequest.builder()
+			.toiletRegistId(1L)
+			.toiletRegistIsApproved(true)
+			.toiletRegistConfirmedDate(DateParsing.LdtToStr(LocalDateTime.now()))
 			.build();
 	}
 

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.personal.registration_service.common.DateParsing;
 import org.personal.registration_service.common.ToiletRegistErrorResult;
 import org.personal.registration_service.domain.ToiletRegist;
 import org.personal.registration_service.exception.ToiletRegistException;
@@ -90,7 +89,6 @@ class ToiletRegistApproveServiceImplTests {
 		return ToiletRegistApproveRequest.builder()
 			.toiletRegistId(1L)
 			.toiletRegistIsApproved(false)
-			.toiletRegistConfirmedDate(DateParsing.LdtToStr(LocalDateTime.now()))
 			.build();
 	}
 
@@ -98,7 +96,6 @@ class ToiletRegistApproveServiceImplTests {
 		return ToiletRegistApproveRequest.builder()
 			.toiletRegistId(1L)
 			.toiletRegistIsApproved(true)
-			.toiletRegistConfirmedDate(DateParsing.LdtToStr(LocalDateTime.now()))
 			.build();
 	}
 

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
@@ -43,6 +43,20 @@ class ToiletRegistApproveServiceImplTests {
 	}
 
 	@Test
+	public void 화장실등록실패_이미처리된신청임(){
+		// given
+		ToiletRegist mockToiletRegist = mock(ToiletRegist.class);
+		doReturn(Optional.of(mockToiletRegist)).when(toiletRegistRepository).findById(1L);
+		doReturn(LocalDateTime.now().toString()).when(mockToiletRegist).getToiletRegistConfirmedDate();
+
+		// when & then
+		assertThatThrownBy(() -> target.updateToiletRegistApprove(requestReject()))
+			.isInstanceOf(ToiletRegistException.class)
+			.hasMessageContaining(  "이미 등록 신청 처리된 화장실입니다.");
+
+	}
+
+	@Test
 	public void 화장실등록성공_반려됨(){
 		// given
 		ToiletRegist mockToiletRegist = mock(ToiletRegist.class);

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistServiceImplTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistServiceImplTests.java
@@ -17,7 +17,7 @@ import org.personal.registration_service.response.ToiletRegistResponse;
 import org.personal.registration_service.service.impl.ToiletRegistServiceImpl;
 
 @ExtendWith(MockitoExtension.class)
-class ToiletRegistServiceTests {
+class ToiletRegistServiceImplTests {
 
 	@InjectMocks
 	private ToiletRegistServiceImpl target;

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistServiceImplTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistServiceImplTests.java
@@ -13,6 +13,7 @@ import org.personal.registration_service.common.ToiletRegistErrorResult;
 import org.personal.registration_service.domain.ToiletRegist;
 import org.personal.registration_service.exception.ToiletRegistException;
 import org.personal.registration_service.repository.ToiletRegistRepository;
+import org.personal.registration_service.request.ToiletRegistRequest;
 import org.personal.registration_service.response.ToiletRegistResponse;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,7 +37,7 @@ class ToiletRegistServiceImplTests {
 
 		// when
 		final ToiletRegistException result = assertThrows(ToiletRegistException.class,
-			() -> target.addToiletRegist(lat, lng));
+			() -> target.addToiletRegist(toiletRegistRequest(lat, lng)));
 
 		// then
 		assertThat(result.getErrorResult()).isEqualTo(ToiletRegistErrorResult.DUPLICATED_TOILET_REGIST_REGISTER);
@@ -49,7 +50,7 @@ class ToiletRegistServiceImplTests {
 		doReturn(toiletRegist()).when(toiletRegistRepository).save(any(ToiletRegist.class));
 
 		// when
-		final ToiletRegistResponse result = target.addToiletRegist(lat, lng);
+		final ToiletRegistResponse result = target.addToiletRegist(toiletRegistRequest(lat, lng));
 
 		// then
 		assertThat(result).isNotNull();
@@ -68,6 +69,13 @@ class ToiletRegistServiceImplTests {
 			.toiletRegistId(1L)        // Mockito를 사용하여 save 메서드를 모킹(mocking)할 때, ID가 자동으로 설정되지 않아 설정해줌.
 			.toiletRegistLatitude(37.123456)
 			.toiletRegistLongitude(127.123456)
+			.build();
+	}
+
+	private ToiletRegistRequest toiletRegistRequest(final Double lat, final Double lng){
+		return ToiletRegistRequest.builder()
+			.toiletRegistLatitude(lat)
+			.toiletRegistLongitude(lng)
 			.build();
 	}
 }

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistServiceImplTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistServiceImplTests.java
@@ -1,4 +1,4 @@
-package org.personal.registration_service.service;
+package org.personal.registration_service.service.impl;
 
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -14,7 +14,6 @@ import org.personal.registration_service.domain.ToiletRegist;
 import org.personal.registration_service.exception.ToiletRegistException;
 import org.personal.registration_service.repository.ToiletRegistRepository;
 import org.personal.registration_service.response.ToiletRegistResponse;
-import org.personal.registration_service.service.impl.ToiletRegistServiceImpl;
 
 @ExtendWith(MockitoExtension.class)
 class ToiletRegistServiceImplTests {
@@ -22,28 +21,32 @@ class ToiletRegistServiceImplTests {
 	@InjectMocks
 	private ToiletRegistServiceImpl target;
 	@Mock
-	private ToiletRegistRepository toileRegistRepository;
+	private ToiletRegistRepository toiletRegistRepository;
 
 	private final Double lat = 37.123456;
 	private final Double lng = 127.123456;
 
 	@Test
-	public void 화장실등록신청실패_이미존재함(){
+	public void 화장실등록신청실패_이미존재함() {
 		// given
-		doReturn(ToiletRegist.builder().build()).when(toileRegistRepository).findByToiletRegistLatitudeAndToiletRegistLongitude(lat,lng);
+		// 스텁이 올바르게 작동하도록 설정
+		doReturn(ToiletRegist.builder().build())
+			.when(toiletRegistRepository)
+			.findByToiletRegistLatitudeAndToiletRegistLongitude(lat, lng);
 
 		// when
-		final ToiletRegistException result = assertThrows(ToiletRegistException.class, () -> target.addToiletRegist(lat, lng));
+		final ToiletRegistException result = assertThrows(ToiletRegistException.class,
+			() -> target.addToiletRegist(lat, lng));
 
 		// then
 		assertThat(result.getErrorResult()).isEqualTo(ToiletRegistErrorResult.DUPLICATED_TOILET_REGIST_REGISTER);
 	}
 
 	@Test
-	public void 화장실등록신청성공(){
+	public void 화장실등록신청성공() {
 		// given
-		doReturn(null).when(toileRegistRepository).findByToiletRegistLatitudeAndToiletRegistLongitude(lat,lng);
-		doReturn(toiletRegist()).when(toileRegistRepository).save(any(ToiletRegist.class));
+		doReturn(null).when(toiletRegistRepository).findByToiletRegistLatitudeAndToiletRegistLongitude(lat, lng);
+		doReturn(toiletRegist()).when(toiletRegistRepository).save(any(ToiletRegist.class));
 
 		// when
 		final ToiletRegistResponse result = target.addToiletRegist(lat, lng);
@@ -55,14 +58,14 @@ class ToiletRegistServiceImplTests {
 		assertThat(result.toiletRegistLongitude()).isEqualTo(lng);
 
 		// verity
-		verify(toileRegistRepository, times(1)).findByToiletRegistLatitudeAndToiletRegistLongitude(lat, lng);
-		verify(toileRegistRepository, times(1)).save(any(ToiletRegist.class));
+		verify(toiletRegistRepository, times(1)).findByToiletRegistLatitudeAndToiletRegistLongitude(lat, lng);
+		verify(toiletRegistRepository, times(1)).save(any(ToiletRegist.class));
 
 	}
 
 	private ToiletRegist toiletRegist() {
 		return ToiletRegist.builder()
-			.toiletRegistId(1L) 		// Mockito를 사용하여 save 메서드를 모킹(mocking)할 때, ID가 자동으로 설정되지 않아 설정해줌.
+			.toiletRegistId(1L)        // Mockito를 사용하여 save 메서드를 모킹(mocking)할 때, ID가 자동으로 설정되지 않아 설정해줌.
 			.toiletRegistLatitude(37.123456)
 			.toiletRegistLongitude(127.123456)
 			.build();


### PR DESCRIPTION
## #️⃣연관된 이슈
- #8 

## 📝작업 내용
- header를 통해 관리자(admin) 여부 확인
- 화장실 Id를 통해 등록 신청 여부 확인
- ToiletRegistConfirmedDate null을 통해 이미 처리된 화장실 등록인지 판단
- RequestBody를 통해 전달받은 승인, 반려를 결정. 완료 시 ToiletRegistConfirmedDate 현재 시각으로 설정

### 📷스크린샷 (선택)


## 💬리뷰 요구사항(선택)