### PR TITLE
[Registration-Service] 화장실 등록 신청 조회, 정렬

### DIFF
--- a/toilet_registration_service/build.gradle
+++ b/toilet_registration_service/build.gradle
@@ -45,11 +45,11 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'com.google.code.gson:gson:2.10.1'
 
-	// QueryDsl 의존성
+	// QueryDSL 의존성
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
 	implementation "com.querydsl:querydsl-core:${queryDslVersion}"
 
-	// QueryDsl 쿼리 타입 생성 (QClass 생성 시 @Entity 탐색)
+	// QueryDSL 쿼리 타입 생성 (QClass 생성 시 @Entity 탐색)
 	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
 
 	// java.lang.NoClassDefFoundError:javax/persistence/Entity 에러 방지
@@ -57,23 +57,26 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 }
 
-// QueryDsl 빌드 옵션 (선택)
-// QueryDsl 디렉토리 경로
-def querydslDir = "$projectDir/src/main/generated"
+// QueryDSL 빌드 옵션
+def querydslDir = "$buildDir/generated/querydsl"
 
-// 경로 추가 >> QueryDsl 소스 코드 컴파일 시 빌드
+// 경로 추가 >> QueryDSL 소스 코드 컴파일 시 빌드
 sourceSets {
-	main.java.srcDirs += [ querydslDir ]
+	main {
+		java {
+			srcDirs += querydslDir
+		}
+	}
 }
 
-// 컴파일 설정(AnnotationProcessor가 생성하는 소스코드를 해당 경로로 설정)
+// 컴파일 설정 (AnnotationProcessor가 생성하는 소스코드를 해당 경로로 설정)
 tasks.withType(JavaCompile) {
 	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
 }
 
-// clean실행 시 마지막 작업으로 디렉토리(QClass) 삭제 >> 충돌 방지
+// clean 실행 시 마지막 작업으로 디렉토리(QClass) 삭제 >> 충돌 방지
 clean.doLast {
-	file(querydslDir).deleteDir()
+	delete querydslDir
 }
 
 tasks.named('test') {

--- a/toilet_registration_service/build.gradle
+++ b/toilet_registration_service/build.gradle
@@ -26,14 +26,15 @@ repositories {
 
 ext {
 	set('snippetsDir', file("build/generated-snippets"))
+	queryDslVersion = '5.0.0'  // QueryDSL 버전 설정
 }
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.hibernate.orm:hibernate-core:6.2.7.Final'  // Hibernate 6.x로 변경
-	implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'  // Jakarta Persistence API로 변경
+	implementation 'org.hibernate.orm:hibernate-core:6.2.7.Final'
+	implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
@@ -43,6 +44,36 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'com.google.code.gson:gson:2.10.1'
+
+	// QueryDsl 의존성
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+	implementation "com.querydsl:querydsl-core:${queryDslVersion}"
+
+	// QueryDsl 쿼리 타입 생성 (QClass 생성 시 @Entity 탐색)
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+
+	// java.lang.NoClassDefFoundError:javax/persistence/Entity 에러 방지
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+}
+
+// QueryDsl 빌드 옵션 (선택)
+// QueryDsl 디렉토리 경로
+def querydslDir = "$projectDir/src/main/generated"
+
+// 경로 추가 >> QueryDsl 소스 코드 컴파일 시 빌드
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+// 컴파일 설정(AnnotationProcessor가 생성하는 소스코드를 해당 경로로 설정)
+tasks.withType(JavaCompile) {
+	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+// clean실행 시 마지막 작업으로 디렉토리(QClass) 삭제 >> 충돌 방지
+clean.doLast {
+	file(querydslDir).deleteDir()
 }
 
 tasks.named('test') {

--- a/toilet_registration_service/src/main/generated/org/personal/registration_service/domain/QToiletRegist.java
+++ b/toilet_registration_service/src/main/generated/org/personal/registration_service/domain/QToiletRegist.java
@@ -1,0 +1,99 @@
+package org.personal.registration_service.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QToiletRegist is a Querydsl query type for ToiletRegist
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QToiletRegist extends EntityPathBase<ToiletRegist> {
+
+    private static final long serialVersionUID = 1375051026L;
+
+    public static final QToiletRegist toiletRegist = new QToiletRegist("toiletRegist");
+
+    public final BooleanPath toiletInfoSafetyFacilityInstallationIsRequired = createBoolean("toiletInfoSafetyFacilityInstallationIsRequired");
+
+    public final StringPath toiletRegistConfirmedDate = createString("toiletRegistConfirmedDate");
+
+    public final StringPath toiletRegistDate = createString("toiletRegistDate");
+
+    public final BooleanPath toiletRegistDiaperChangingTableIsAvailable = createBoolean("toiletRegistDiaperChangingTableIsAvailable");
+
+    public final StringPath toiletRegistDiaperChangingTableLocation = createString("toiletRegistDiaperChangingTableLocation");
+
+    public final BooleanPath toiletRegistEmergencyBellIsInstalled = createBoolean("toiletRegistEmergencyBellIsInstalled");
+
+    public final StringPath toiletRegistEmergencyBellLocation = createString("toiletRegistEmergencyBellLocation");
+
+    public final BooleanPath toiletRegistEntranceCctvIsInstalled = createBoolean("toiletRegistEntranceCctvIsInstalled");
+
+    public final NumberPath<Integer> toiletRegistFemaleChildToiletsNumber = createNumber("toiletRegistFemaleChildToiletsNumber", Integer.class);
+
+    public final NumberPath<Integer> toiletRegistFemaleDisabledToiletsNumber = createNumber("toiletRegistFemaleDisabledToiletsNumber", Integer.class);
+
+    public final NumberPath<Integer> toiletRegistFemaleToiletsNumber = createNumber("toiletRegistFemaleToiletsNumber", Integer.class);
+
+    public final NumberPath<Long> toiletRegistId = createNumber("toiletRegistId", Long.class);
+
+    public final StringPath toiletRegistInstallationYearMonth = createString("toiletRegistInstallationYearMonth");
+
+    public final BooleanPath toiletRegistIsApproved = createBoolean("toiletRegistIsApproved");
+
+    public final NumberPath<Double> toiletRegistLatitude = createNumber("toiletRegistLatitude", Double.class);
+
+    public final NumberPath<Double> toiletRegistLongitude = createNumber("toiletRegistLongitude", Double.class);
+
+    public final NumberPath<Integer> toiletRegistMaleChildToiletsNumber = createNumber("toiletRegistMaleChildToiletsNumber", Integer.class);
+
+    public final NumberPath<Integer> toiletRegistMaleChildUrinalsNumber = createNumber("toiletRegistMaleChildUrinalsNumber", Integer.class);
+
+    public final NumberPath<Integer> toiletRegistMaleDisabledToiletsNumber = createNumber("toiletRegistMaleDisabledToiletsNumber", Integer.class);
+
+    public final NumberPath<Integer> toiletRegistMaleDisabledUrinalsNumber = createNumber("toiletRegistMaleDisabledUrinalsNumber", Integer.class);
+
+    public final NumberPath<Integer> toiletRegistMaleToiletsNumber = createNumber("toiletRegistMaleToiletsNumber", Integer.class);
+
+    public final NumberPath<Integer> toiletRegistMaleUrinalsNumber = createNumber("toiletRegistMaleUrinalsNumber", Integer.class);
+
+    public final StringPath toiletRegistManagementAgency = createString("toiletRegistManagementAgency");
+
+    public final StringPath toiletRegistNumberAddress = createString("toiletRegistNumberAddress");
+
+    public final StringPath toiletRegistOpeningHours = createString("toiletRegistOpeningHours");
+
+    public final StringPath toiletRegistOpeningHoursDetails = createString("toiletRegistOpeningHoursDetails");
+
+    public final StringPath toiletRegistOwnershipType = createString("toiletRegistOwnershipType");
+
+    public final StringPath toiletRegistPhoneNumber = createString("toiletRegistPhoneNumber");
+
+    public final StringPath toiletRegistRoadNameAddress = createString("toiletRegistRoadNameAddress");
+
+    public final StringPath toiletRegistToiletName = createString("toiletRegistToiletName");
+
+    public final StringPath toiletRegistWasteDisposalMethod = createString("toiletRegistWasteDisposalMethod");
+
+    public final StringPath userEmail = createString("userEmail");
+
+    public QToiletRegist(String variable) {
+        super(ToiletRegist.class, forVariable(variable));
+    }
+
+    public QToiletRegist(Path<? extends ToiletRegist> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QToiletRegist(PathMetadata metadata) {
+        super(ToiletRegist.class, metadata);
+    }
+
+}
+

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/common/Constants.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/common/Constants.java
@@ -10,4 +10,5 @@ public final class Constants {
 	public final static String ADMIN = "admin";
 	public final static String APPROVE = "approve";
 	public final static String REJECT = "reject";
+	public final static int PAGE_SIZE = 10;
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/common/config/QueryDSLConfig.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/common/config/QueryDSLConfig.java
@@ -1,0 +1,21 @@
+package org.personal.registration_service.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnit;
+
+@Configuration
+public class QueryDSLConfig {
+
+	@PersistenceUnit
+	private EntityManagerFactory entityManagerFactory;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		EntityManager entityManager = entityManagerFactory.createEntityManager();
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/common/config/WebConfig.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/common/config/WebConfig.java
@@ -1,0 +1,19 @@
+package org.personal.registration_service.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins("http://localhost:5173") // Vue.js 개발 서버 도메인
+			.allowedMethods("GET", "POST", "PUT", "DELETE") // 허용할 HTTP 메소드
+			.allowedHeaders("*") // 허용할 헤더
+			.allowCredentials(true) // 자격 증명 허용 (쿠키 등)
+			.maxAge(3600); // 프리플라이트 요청 캐시 시간 (초)
+	}
+}

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/common/config/WebConfig.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/common/config/WebConfig.java
@@ -11,7 +11,7 @@ public class WebConfig implements WebMvcConfigurer {
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
 			.allowedOrigins("http://localhost:5173") // Vue.js 개발 서버 도메인
-			.allowedMethods("GET", "POST", "PUT", "DELETE") // 허용할 HTTP 메소드
+			.allowedMethods("GET", "POST", "PUT", "DELETE", "Patch") // 허용할 HTTP 메소드
 			.allowedHeaders("*") // 허용할 헤더
 			.allowCredentials(true) // 자격 증명 허용 (쿠키 등)
 			.maxAge(3600); // 프리플라이트 요청 캐시 시간 (초)

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistApproveController.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistApproveController.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,8 +51,8 @@ public class ToiletRegistApproveController {
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 
-	@GetMapping
-	public ResponseEntity<ToiletRegistResponse> getToiletRegist(@RequestParam long toiletRegistId){
+	@GetMapping("{toiletRegistId}")
+	public ResponseEntity<ToiletRegistResponse> getToiletRegist(@PathVariable long toiletRegistId){
 		ToiletRegistResponse response = toiletRegistApproveService.getToiletRegist(toiletRegistId);
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistApproveController.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistApproveController.java
@@ -50,7 +50,7 @@ public class ToiletRegistApproveController {
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 
-	@GetMapping("{toiletRegistId}")
+	@GetMapping
 	public ResponseEntity<ToiletRegistResponse> getToiletRegist(@RequestParam long toiletRegistId){
 		ToiletRegistResponse response = toiletRegistApproveService.getToiletRegist(toiletRegistId);
 		return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistApproveController.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistApproveController.java
@@ -6,13 +6,16 @@ import org.personal.registration_service.common.ToiletRegistErrorResult;
 import org.personal.registration_service.exception.ToiletRegistException;
 import org.personal.registration_service.request.ToiletRegistApproveRequest;
 import org.personal.registration_service.response.ToiletRegistApproveResponse;
+import org.personal.registration_service.response.ToiletRegistResponse;
 import org.personal.registration_service.service.ToiletRegistApproveService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -43,6 +46,12 @@ public class ToiletRegistApproveController {
 
 		ToiletRegistApproveResponse response = toiletRegistApproveService.updateToiletRegistApprove(request);
 
+		return ResponseEntity.status(HttpStatus.OK).body(response);
+	}
+
+	@GetMapping("{toiletRegistId}")
+	public ResponseEntity<ToiletRegistResponse> getToiletRegist(@RequestParam long toiletRegistId){
+		ToiletRegistResponse response = toiletRegistApproveService.getToiletRegist(toiletRegistId);
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistApproveController.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/controller/ToiletRegistApproveController.java
@@ -8,6 +8,7 @@ import org.personal.registration_service.request.ToiletRegistApproveRequest;
 import org.personal.registration_service.response.ToiletRegistApproveResponse;
 import org.personal.registration_service.response.ToiletRegistResponse;
 import org.personal.registration_service.service.ToiletRegistApproveService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -53,5 +54,11 @@ public class ToiletRegistApproveController {
 	public ResponseEntity<ToiletRegistResponse> getToiletRegist(@RequestParam long toiletRegistId){
 		ToiletRegistResponse response = toiletRegistApproveService.getToiletRegist(toiletRegistId);
 		return ResponseEntity.status(HttpStatus.OK).body(response);
+	}
+
+	@GetMapping
+	public ResponseEntity<Page<ToiletRegistResponse>> listToiletRegist(@RequestParam(defaultValue = "0") int pageNum){
+		Page<ToiletRegistResponse> responses = toiletRegistApproveService.listToiletRegist(pageNum);
+		return ResponseEntity.status(HttpStatus.OK).body(responses);
 	}
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/repository/QueryDSLRepository.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/repository/QueryDSLRepository.java
@@ -3,8 +3,13 @@ package org.personal.registration_service.repository;
 import java.util.Optional;
 
 import org.personal.registration_service.domain.ToiletRegist;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface QueryDSLRepository {
 
-	Optional<ToiletRegist> findBytoiletRegistId(long toiletRegistId);
+	Optional<ToiletRegist> findByToiletRegistId(long toiletRegistId);
+
+	Page<ToiletRegist> findAllByPageable(Pageable pageable);
 }
+

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/repository/QueryDSLRepository.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/repository/QueryDSLRepository.java
@@ -1,0 +1,10 @@
+package org.personal.registration_service.repository;
+
+import java.util.Optional;
+
+import org.personal.registration_service.domain.ToiletRegist;
+
+public interface QueryDSLRepository {
+
+	Optional<ToiletRegist> findBytoiletRegistId(long toiletRegistId);
+}

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/repository/ToiletRegistRepository.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/repository/ToiletRegistRepository.java
@@ -3,6 +3,6 @@ package org.personal.registration_service.repository;
 import org.personal.registration_service.domain.ToiletRegist;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ToiletRegistRepository extends JpaRepository<ToiletRegist, Long> {
+public interface ToiletRegistRepository extends JpaRepository<ToiletRegist, Long>, QueryDSLRepository {
 }
 

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/repository/impl/QueryDSLRepositoryImpl.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/repository/impl/QueryDSLRepositoryImpl.java
@@ -2,11 +2,15 @@ package org.personal.registration_service.repository.impl;
 
 import static org.personal.registration_service.domain.QToiletRegist.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.personal.registration_service.domain.ToiletRegist;
 import org.personal.registration_service.repository.QueryDSLRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -22,12 +26,27 @@ public class QueryDSLRepositoryImpl implements QueryDSLRepository {
 	}
 
 	@Override
-	public Optional<ToiletRegist> findBytoiletRegistId(long toiletRegistId) {
+	public Optional<ToiletRegist> findByToiletRegistId(long toiletRegistId) {
 		ToiletRegist result = queryFactory
 			.selectFrom(toiletRegist)
 			.where(toiletRegist.toiletRegistId.eq(toiletRegistId))
 			.fetchOne();
 
 		return Optional.ofNullable(result);
+	}
+
+
+	public Page<ToiletRegist> findAllByPageable(Pageable pageable) {
+		List<ToiletRegist> results = queryFactory
+			.selectFrom(toiletRegist)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		long total = queryFactory
+			.selectFrom(toiletRegist)
+			.fetchCount();
+
+		return new PageImpl<>(results, pageable, total);
 	}
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/repository/impl/QueryDSLRepositoryImpl.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/repository/impl/QueryDSLRepositoryImpl.java
@@ -5,20 +5,20 @@ import static org.personal.registration_service.domain.QToiletRegist.*;
 import java.util.List;
 import java.util.Optional;
 
+import org.personal.registration_service.domain.QToiletRegist;
 import org.personal.registration_service.domain.ToiletRegist;
 import org.personal.registration_service.repository.QueryDSLRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 @Repository
 public class QueryDSLRepositoryImpl implements QueryDSLRepository {
 
-	@Autowired
 	private final JPAQueryFactory queryFactory;
 
 	public QueryDSLRepositoryImpl(JPAQueryFactory queryFactory) {
@@ -35,12 +35,15 @@ public class QueryDSLRepositoryImpl implements QueryDSLRepository {
 		return Optional.ofNullable(result);
 	}
 
-
+	@Override
 	public Page<ToiletRegist> findAllByPageable(Pageable pageable) {
+		OrderSpecifier<?> orderSpecifier = QToiletRegist.toiletRegist.toiletRegistConfirmedDate.asc().nullsFirst();
+
 		List<ToiletRegist> results = queryFactory
 			.selectFrom(toiletRegist)
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
+			.orderBy(orderSpecifier)
 			.fetch();
 
 		long total = queryFactory
@@ -50,3 +53,4 @@ public class QueryDSLRepositoryImpl implements QueryDSLRepository {
 		return new PageImpl<>(results, pageable, total);
 	}
 }
+

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/repository/impl/QueryDSLRepositoryImpl.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/repository/impl/QueryDSLRepositoryImpl.java
@@ -1,0 +1,33 @@
+package org.personal.registration_service.repository.impl;
+
+import static org.personal.registration_service.domain.QToiletRegist.*;
+
+import java.util.Optional;
+
+import org.personal.registration_service.domain.ToiletRegist;
+import org.personal.registration_service.repository.QueryDSLRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@Repository
+public class QueryDSLRepositoryImpl implements QueryDSLRepository {
+
+	@Autowired
+	private final JPAQueryFactory queryFactory;
+
+	public QueryDSLRepositoryImpl(JPAQueryFactory queryFactory) {
+		this.queryFactory = queryFactory;
+	}
+
+	@Override
+	public Optional<ToiletRegist> findBytoiletRegistId(long toiletRegistId) {
+		ToiletRegist result = queryFactory
+			.selectFrom(toiletRegist)
+			.where(toiletRegist.toiletRegistId.eq(toiletRegistId))
+			.fetchOne();
+
+		return Optional.ofNullable(result);
+	}
+}

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/service/ToiletRegistApproveService.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/service/ToiletRegistApproveService.java
@@ -2,7 +2,10 @@ package org.personal.registration_service.service;
 
 import org.personal.registration_service.request.ToiletRegistApproveRequest;
 import org.personal.registration_service.response.ToiletRegistApproveResponse;
+import org.personal.registration_service.response.ToiletRegistResponse;
 
 public interface ToiletRegistApproveService {
 	ToiletRegistApproveResponse updateToiletRegistApprove(ToiletRegistApproveRequest request);
+
+	ToiletRegistResponse getToiletRegist(long toiletRegistId);
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/service/ToiletRegistApproveService.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/service/ToiletRegistApproveService.java
@@ -3,9 +3,14 @@ package org.personal.registration_service.service;
 import org.personal.registration_service.request.ToiletRegistApproveRequest;
 import org.personal.registration_service.response.ToiletRegistApproveResponse;
 import org.personal.registration_service.response.ToiletRegistResponse;
+import org.springframework.data.domain.Page;
 
 public interface ToiletRegistApproveService {
+
 	ToiletRegistApproveResponse updateToiletRegistApprove(ToiletRegistApproveRequest request);
 
 	ToiletRegistResponse getToiletRegist(long toiletRegistId);
+
+	Page<ToiletRegistResponse> listToiletRegist(int pageNum);
+
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImpl.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImpl.java
@@ -3,13 +3,16 @@ package org.personal.registration_service.service.impl;
 import static org.personal.registration_service.common.Constants.*;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.personal.registration_service.common.ToiletRegistErrorResult;
 import org.personal.registration_service.domain.ToiletRegist;
 import org.personal.registration_service.exception.ToiletRegistException;
+import org.personal.registration_service.repository.QueryDSLRepository;
 import org.personal.registration_service.repository.ToiletRegistRepository;
 import org.personal.registration_service.request.ToiletRegistApproveRequest;
 import org.personal.registration_service.response.ToiletRegistApproveResponse;
+import org.personal.registration_service.response.ToiletRegistResponse;
 import org.personal.registration_service.service.ToiletRegistApproveService;
 import org.springframework.stereotype.Service;
 
@@ -24,7 +27,7 @@ public class ToiletRegistApproveServiceImpl implements ToiletRegistApproveServic
 	@Override
 	public ToiletRegistApproveResponse updateToiletRegistApprove(ToiletRegistApproveRequest request) {
 		final ToiletRegist toiletRegist = toiletRegistRepository.findById(request.toiletRegistId())
-		.orElseThrow(() -> new ToiletRegistException(ToiletRegistErrorResult.ENTITY_NOT_FOUND));
+			.orElseThrow(() -> new ToiletRegistException(ToiletRegistErrorResult.ENTITY_NOT_FOUND));
 
 		// 이미 등록 처리된 화장실인지 확인
 		if (toiletRegist.getToiletRegistConfirmedDate() != null) {
@@ -37,5 +40,12 @@ public class ToiletRegistApproveServiceImpl implements ToiletRegistApproveServic
 		String status = request.isApproved() ? APPROVE : REJECT;
 
 		return new ToiletRegistApproveResponse(status);
+	}
+
+	@Override
+	public ToiletRegistResponse getToiletRegist(long toiletRegistId) {
+		ToiletRegist toiletRegist = toiletRegistRepository.findBytoiletRegistId(toiletRegistId)
+			.orElseThrow(() -> new ToiletRegistException(ToiletRegistErrorResult.ENTITY_NOT_FOUND));
+		return ToiletRegistResponse.of(toiletRegist);
 	}
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImpl.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImpl.java
@@ -3,17 +3,18 @@ package org.personal.registration_service.service.impl;
 import static org.personal.registration_service.common.Constants.*;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import org.personal.registration_service.common.ToiletRegistErrorResult;
 import org.personal.registration_service.domain.ToiletRegist;
 import org.personal.registration_service.exception.ToiletRegistException;
-import org.personal.registration_service.repository.QueryDSLRepository;
 import org.personal.registration_service.repository.ToiletRegistRepository;
 import org.personal.registration_service.request.ToiletRegistApproveRequest;
 import org.personal.registration_service.response.ToiletRegistApproveResponse;
 import org.personal.registration_service.response.ToiletRegistResponse;
 import org.personal.registration_service.service.ToiletRegistApproveService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -44,8 +45,22 @@ public class ToiletRegistApproveServiceImpl implements ToiletRegistApproveServic
 
 	@Override
 	public ToiletRegistResponse getToiletRegist(long toiletRegistId) {
-		ToiletRegist toiletRegist = toiletRegistRepository.findBytoiletRegistId(toiletRegistId)
+		ToiletRegist toiletRegist = toiletRegistRepository.findByToiletRegistId(toiletRegistId)
 			.orElseThrow(() -> new ToiletRegistException(ToiletRegistErrorResult.ENTITY_NOT_FOUND));
 		return ToiletRegistResponse.of(toiletRegist);
+	}
+
+	@Override
+	public Page<ToiletRegistResponse> listToiletRegist(int pageNum) {
+		Pageable pageable = PageRequest.of(pageNum, PAGE_SIZE);
+
+		Page<ToiletRegist> toiletRegists = toiletRegistRepository.findAllByPageable(pageable);
+
+		// 조회된 결과가 비어 있는지 확인
+		if (toiletRegists.isEmpty()) {
+			throw new ToiletRegistException(ToiletRegistErrorResult.ENTITY_NOT_FOUND);
+		}
+
+		return toiletRegists.map(ToiletRegistResponse::of);
 	}
 }

--- a/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistServiceImpl.java
+++ b/toilet_registration_service/src/main/java/org/personal/registration_service/service/impl/ToiletRegistServiceImpl.java
@@ -1,8 +1,6 @@
 package org.personal.registration_service.service.impl;
 
-import org.personal.registration_service.common.ToiletRegistErrorResult;
 import org.personal.registration_service.domain.ToiletRegist;
-import org.personal.registration_service.exception.ToiletRegistException;
 import org.personal.registration_service.repository.ToiletRegistRepository;
 import org.personal.registration_service.request.ToiletRegistRequest;
 import org.personal.registration_service.response.ToiletRegistResponse;
@@ -21,9 +19,7 @@ public class ToiletRegistServiceImpl implements ToiletRegistService {
 	public ToiletRegistResponse addToiletRegist(ToiletRegistRequest request){
 
 		final ToiletRegist toiletRegist = ToiletRegist.of(request);
-
 		final ToiletRegist savedToiletRegist = toiletRegistRepository.save(toiletRegist);
-
 		return ToiletRegistResponse.of(savedToiletRegist);
 	}
 }

--- a/toilet_registration_service/src/main/resources/application.yml
+++ b/toilet_registration_service/src/main/resources/application.yml
@@ -5,4 +5,4 @@ spring:
   application:
     name: user_service
   profiles:
-    active: h2 #,postgresql # 기본 프로파일을 h2와 postgresql로 설정합니다.
+    active: h2 ,postgresql # 기본 프로파일을 h2와 postgresql로 설정합니다.

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
@@ -2,7 +2,10 @@ package org.personal.registration_service.controller;
 
 import static org.mockito.Mockito.*;
 import static org.personal.registration_service.common.Constants.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Arrays;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +19,10 @@ import org.personal.registration_service.exception.ToiletRegistException;
 import org.personal.registration_service.request.ToiletRegistApproveRequest;
 import org.personal.registration_service.response.ToiletRegistResponse;
 import org.personal.registration_service.service.impl.ToiletRegistApproveServiceImpl;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -156,6 +163,36 @@ class ToiletRegistApproveControllerTests {
 
 		// then
 		resultActions.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void 화장실등록신청전체조회성공() throws Exception {
+		// given
+		final String url = "/approves";
+		ToiletRegistResponse response1 = ToiletRegistResponse.builder()
+			.toiletRegistId(1L)
+			.toiletRegistToiletName("화장실 1")
+			.build();
+
+		ToiletRegistResponse response2 = ToiletRegistResponse.builder()
+			.toiletRegistId(2L)
+			.toiletRegistToiletName("화장실 2")
+			.build();
+
+		Pageable pageable = PageRequest.of(0, 10);
+		Page<ToiletRegistResponse> page = new PageImpl<>(Arrays.asList(response1, response2), pageable, 2);
+
+		when(toiletRegistApproveService.listToiletRegist(0)).thenReturn(page);
+
+		// when & then
+		mockMvc.perform(get(url) // 실제 엔드포인트로 변경하세요
+				.param("pageNum", "0")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content[0].toiletRegistId").value(1L))
+			.andExpect(jsonPath("$.content[0].toiletRegistToiletName").value("화장실 1"))
+			.andExpect(jsonPath("$.content[1].toiletRegistId").value(2L))
+			.andExpect(jsonPath("$.content[1].toiletRegistToiletName").value("화장실 2"));
 	}
 
 	private ToiletRegistApproveRequest toiletRegistRequest() {

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/controller/ToiletRegistApproveControllerTests.java
@@ -1,5 +1,6 @@
 package org.personal.registration_service.controller;
 
+import static org.mockito.Mockito.*;
 import static org.personal.registration_service.common.Constants.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -9,8 +10,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.personal.registration_service.common.ToiletRegistErrorResult;
 import org.personal.registration_service.exception.GlobalExceptionHandler;
+import org.personal.registration_service.exception.ToiletRegistException;
 import org.personal.registration_service.request.ToiletRegistApproveRequest;
+import org.personal.registration_service.response.ToiletRegistResponse;
 import org.personal.registration_service.service.impl.ToiletRegistApproveServiceImpl;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -84,6 +88,74 @@ class ToiletRegistApproveControllerTests {
 
 		// then
 		resultActions.andExpect(status().isOk());
+	}
+
+	@Test
+	public void 특정화장실등록조회_성공() throws Exception {
+		// given
+		final String url = "/approves/1";
+
+		ToiletRegistResponse response = ToiletRegistResponse.builder()
+			.toiletRegistId(1L)
+			.toiletRegistDate("2023-01-01")
+			.toiletRegistIsApproved(true)
+			.toiletRegistConfirmedDate("2023-01-02")
+			.toiletRegistToiletName("예시 화장실")
+			.toiletRegistRoadNameAddress("서울특별시")
+			.toiletRegistNumberAddress("123-456")
+			.toiletRegistLatitude(37.5665)
+			.toiletRegistLongitude(126.9780)
+			.toiletRegistManagementAgency("관리기관")
+			.toiletRegistPhoneNumber("010-1234-5678")
+			.toiletRegistOpeningHours("09:00-18:00")
+			.toiletRegistOpeningHoursDetails("평일만 운영")
+			.toiletRegistInstallationYearMonth("2020-01")
+			.toiletRegistOwnershipType("공공")
+			.toiletRegistWasteDisposalMethod("하수")
+			.toiletInfoSafetyFacilityInstallationIsRequired(true)
+			.toiletRegistEmergencyBellIsInstalled(true)
+			.toiletRegistEmergencyBellLocation("입구 근처")
+			.toiletRegistEntranceCctvIsInstalled(true)
+			.toiletRegistDiaperChangingTableIsAvailable(true)
+			.toiletRegistDiaperChangingTableLocation("메인 홀 근처")
+			.toiletRegistMaleToiletsNumber(3)
+			.toiletRegistMaleUrinalsNumber(2)
+			.toiletRegistMaleDisabledToiletsNumber(1)
+			.toiletRegistMaleDisabledUrinalsNumber(1)
+			.toiletRegistMaleChildToiletsNumber(1)
+			.toiletRegistMaleChildUrinalsNumber(1)
+			.toiletRegistFemaleToiletsNumber(3)
+			.toiletRegistFemaleDisabledToiletsNumber(1)
+			.toiletRegistFemaleChildToiletsNumber(1)
+			.userEmail("user@example.com")
+			.build();
+
+		when(toiletRegistApproveService.getToiletRegist(1L)).thenReturn(response);
+
+		// when
+		final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get(url)
+			.param("toiletRegistId", "1")
+			.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.toiletRegistToiletName").value("예시 화장실"));
+	}
+
+	@Test
+	public void 특정화장실등록조회실패_존재하지않음() throws Exception {
+		// given
+		final String url = "/approves/1";
+		when(toiletRegistApproveService.getToiletRegist(1L))
+			.thenThrow(new ToiletRegistException(ToiletRegistErrorResult.ENTITY_NOT_FOUND));
+
+		// when
+		final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get(url)
+			.param("toiletRegistId", "1")
+			.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions.andExpect(status().isNotFound());
 	}
 
 	private ToiletRegistApproveRequest toiletRegistRequest() {

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/repository/ToiletRegistRepositoryTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/repository/ToiletRegistRepositoryTests.java
@@ -6,8 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.personal.registration_service.domain.ToiletRegist;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 
-@DataJpaTest
+@SpringBootTest
 class ToiletRegistRepositoryTests {
 
 	@Autowired

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/repository/impl/QueryDSLRepositoryImplTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/repository/impl/QueryDSLRepositoryImplTests.java
@@ -1,0 +1,89 @@
+package org.personal.registration_service.repository.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.personal.registration_service.domain.QToiletRegist;
+import org.personal.registration_service.domain.ToiletRegist;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class QueryDSLRepositoryImplTests {
+
+	@InjectMocks
+	private QueryDSLRepositoryImpl queryDSLRepositoryImpl;
+
+	@Mock
+	private JPAQueryFactory queryFactory;
+
+	@Mock
+	private JPAQuery<ToiletRegist> jpaQuery;
+
+	@Test
+	public void findAllByPageable_성공() {
+		// given
+		ToiletRegist toiletRegist1 = ToiletRegist.builder()
+			.toiletRegistId(1L)
+			.toiletRegistToiletName("화장실 1")
+			.build();
+
+		ToiletRegist toiletRegist2 = ToiletRegist.builder()
+			.toiletRegistId(2L)
+			.toiletRegistToiletName("화장실 2")
+			.build();
+
+		List<ToiletRegist> toiletRegists = Arrays.asList(toiletRegist1, toiletRegist2);
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// mocking
+		when(queryFactory.selectFrom(QToiletRegist.toiletRegist)).thenReturn(jpaQuery);
+		when(jpaQuery.offset(pageable.getOffset())).thenReturn(jpaQuery);
+		when(jpaQuery.limit(pageable.getPageSize())).thenReturn(jpaQuery);
+		when(jpaQuery.fetch()).thenReturn(toiletRegists);
+		when(jpaQuery.fetchCount()).thenReturn((long) toiletRegists.size());
+
+		// when
+		Page<ToiletRegist> result = queryDSLRepositoryImpl.findAllByPageable(pageable);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(2);
+		assertThat(result.getContent().get(0).getToiletRegistId()).isEqualTo(1L);
+		assertThat(result.getContent().get(1).getToiletRegistId()).isEqualTo(2L);
+	}
+
+	@Test
+	public void findAllByPageable_실패_빈결과() {
+		// given
+		Pageable pageable = PageRequest.of(0, 10);
+		List<ToiletRegist> emptyList = Arrays.asList();
+
+		// mocking
+		when(queryFactory.selectFrom(QToiletRegist.toiletRegist)).thenReturn(jpaQuery);
+		when(jpaQuery.offset(pageable.getOffset())).thenReturn(jpaQuery);
+		when(jpaQuery.limit(pageable.getPageSize())).thenReturn(jpaQuery);
+		when(jpaQuery.fetch()).thenReturn(emptyList);
+		when(jpaQuery.fetchCount()).thenReturn(0L);
+
+		// when
+		Page<ToiletRegist> result = queryDSLRepositoryImpl.findAllByPageable(pageable);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).isEmpty();
+	}
+}

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/repository/impl/QueryDSLRepositoryImplTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/repository/impl/QueryDSLRepositoryImplTests.java
@@ -16,10 +16,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import static org.mockito.Mockito.*;
+import static org.personal.registration_service.domain.QToiletRegist.*;
 
 @ExtendWith(MockitoExtension.class)
 class QueryDSLRepositoryImplTests {
@@ -49,10 +51,13 @@ class QueryDSLRepositoryImplTests {
 		List<ToiletRegist> toiletRegists = Arrays.asList(toiletRegist1, toiletRegist2);
 		Pageable pageable = PageRequest.of(0, 10);
 
-		// mocking
-		when(queryFactory.selectFrom(QToiletRegist.toiletRegist)).thenReturn(jpaQuery);
+		// 모의 데이터 설정
+		OrderSpecifier<?> orderSpecifier = QToiletRegist.toiletRegist.toiletRegistConfirmedDate.asc().nullsFirst();
+
+		when(queryFactory.selectFrom(toiletRegist)).thenReturn(jpaQuery);
 		when(jpaQuery.offset(pageable.getOffset())).thenReturn(jpaQuery);
 		when(jpaQuery.limit(pageable.getPageSize())).thenReturn(jpaQuery);
+		when(jpaQuery.orderBy(orderSpecifier)).thenReturn(jpaQuery);  // 명시적인 orderSpecifier 사용
 		when(jpaQuery.fetch()).thenReturn(toiletRegists);
 		when(jpaQuery.fetchCount()).thenReturn((long) toiletRegists.size());
 
@@ -72,10 +77,14 @@ class QueryDSLRepositoryImplTests {
 		Pageable pageable = PageRequest.of(0, 10);
 		List<ToiletRegist> emptyList = Arrays.asList();
 
+		// `OrderSpecifier` 명시적 생성
+		OrderSpecifier<?> orderSpecifier = QToiletRegist.toiletRegist.toiletRegistConfirmedDate.asc().nullsFirst();
+
 		// mocking
-		when(queryFactory.selectFrom(QToiletRegist.toiletRegist)).thenReturn(jpaQuery);
+		when(queryFactory.selectFrom(toiletRegist)).thenReturn(jpaQuery);
 		when(jpaQuery.offset(pageable.getOffset())).thenReturn(jpaQuery);
 		when(jpaQuery.limit(pageable.getPageSize())).thenReturn(jpaQuery);
+		when(jpaQuery.orderBy(orderSpecifier)).thenReturn(jpaQuery);  // 명시적으로 `orderSpecifier`를 사용
 		when(jpaQuery.fetch()).thenReturn(emptyList);
 		when(jpaQuery.fetchCount()).thenReturn(0L);
 
@@ -86,4 +95,5 @@ class QueryDSLRepositoryImplTests {
 		assertThat(result).isNotNull();
 		assertThat(result.getContent()).isEmpty();
 	}
+
 }

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
@@ -248,7 +248,7 @@ class ToiletRegistApproveServiceImplTests {
 			.build();
 
 		Pageable pageable = PageRequest.of(0, 10);
-		List<ToiletRegist> toiletRegistList = Arrays.asList(toiletRegist1, toiletRegist2);
+		List<ToiletRegist> toiletRegistList = Arrays.asList(toiletRegist2, toiletRegist1);
 		Page<ToiletRegist> page = new PageImpl<>(toiletRegistList, pageable, toiletRegistList.size());
 
 		doReturn(page).when(toiletRegistRepository).findAllByPageable(pageable);

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
@@ -183,7 +183,6 @@ class ToiletRegistApproveServiceImplTests {
 		assertThat(exception.getErrorResult()).isEqualTo(ToiletRegistErrorResult.ENTITY_NOT_FOUND);
 	}
 
-
 	@Test
 	public void 화장실전체조회_성공() {
 		// given
@@ -233,6 +232,41 @@ class ToiletRegistApproveServiceImplTests {
 		assertThat(exception.getErrorResult()).isEqualTo(ToiletRegistErrorResult.ENTITY_NOT_FOUND);
 	}
 
+	@Test
+	public void 화장실전체조회정렬테스트() {
+		// given
+		ToiletRegist toiletRegist1 = ToiletRegist.builder()
+			.toiletRegistId(1L)
+			.toiletRegistToiletName("화장실 1")
+			.toiletRegistConfirmedDate("2024-08-13")
+			.build();
+
+		ToiletRegist toiletRegist2 = ToiletRegist.builder()
+			.toiletRegistId(2L)
+			.toiletRegistToiletName("화장실 2")
+			.toiletRegistConfirmedDate(null)
+			.build();
+
+		Pageable pageable = PageRequest.of(0, 10);
+		List<ToiletRegist> toiletRegistList = Arrays.asList(toiletRegist1, toiletRegist2);
+		Page<ToiletRegist> page = new PageImpl<>(toiletRegistList, pageable, toiletRegistList.size());
+
+		doReturn(page).when(toiletRegistRepository).findAllByPageable(pageable);
+
+		// when
+		Page<ToiletRegistResponse> result = target.listToiletRegist(0);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent().size()).isEqualTo(2);
+		assertThat(result.getContent().get(0).toiletRegistId()).isEqualTo(2L);
+		assertThat(result.getContent().get(0).toiletRegistConfirmedDate()).isEqualTo(null);
+		assertThat(result.getContent().get(0).toiletRegistToiletName()).isEqualTo("화장실 2");
+		assertThat(result.getContent().get(1).toiletRegistId()).isEqualTo(1L);
+		assertThat(result.getContent().get(1).toiletRegistToiletName()).isEqualTo("화장실 1");
+		assertThat(result.getContent().get(1).toiletRegistConfirmedDate()).isEqualTo("2024-08-13");
+	}
+
 	private ToiletRegistApproveRequest requestReject(){
 		return ToiletRegistApproveRequest.builder()
 			.toiletRegistId(1L)
@@ -246,5 +280,4 @@ class ToiletRegistApproveServiceImplTests {
 			.isApproved(true)
 			.build();
 	}
-
 }

--- a/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
+++ b/toilet_registration_service/src/test/java/org/personal/registration_service/service/impl/ToiletRegistApproveServiceImplTests.java
@@ -8,6 +8,7 @@ import static org.personal.registration_service.common.Constants.*;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,6 +20,7 @@ import org.personal.registration_service.exception.ToiletRegistException;
 import org.personal.registration_service.repository.ToiletRegistRepository;
 import org.personal.registration_service.request.ToiletRegistApproveRequest;
 import org.personal.registration_service.response.ToiletRegistApproveResponse;
+import org.personal.registration_service.response.ToiletRegistResponse;
 
 @ExtendWith(MockitoExtension.class)
 class ToiletRegistApproveServiceImplTests {
@@ -83,6 +85,97 @@ class ToiletRegistApproveServiceImplTests {
 		// then
 		assertThat(result).isNotNull();
 		assertThat(result.message()).isEqualTo(APPROVE);
+	}
+
+	@Test
+	public void 화장실등록조회_성공() {
+		// given
+		ToiletRegist mockToiletRegist = ToiletRegist.builder()
+			.toiletRegistId(1L)
+			.toiletRegistDate("2023-08-12")
+			.toiletRegistIsApproved(true)
+			.toiletRegistConfirmedDate("2023-08-13")
+			.toiletRegistToiletName("서울역 화장실")
+			.toiletRegistRoadNameAddress("서울시 용산구 한강대로 405")
+			.toiletRegistNumberAddress("서울시 용산구 남대문로 20")
+			.toiletRegistLatitude(37.5551)
+			.toiletRegistLongitude(126.9707)
+			.toiletRegistManagementAgency("용산구청")
+			.toiletRegistPhoneNumber("02-123-4567")
+			.toiletRegistOpeningHours("24시간")
+			.toiletRegistOpeningHoursDetails("연중무휴")
+			.toiletRegistInstallationYearMonth("2020-05")
+			.toiletRegistOwnershipType("공공")
+			.toiletRegistWasteDisposalMethod("정화조")
+			.toiletInfoSafetyFacilityInstallationIsRequired(true)
+			.toiletRegistEmergencyBellIsInstalled(true)
+			.toiletRegistEmergencyBellLocation("남자화장실 입구")
+			.toiletRegistEntranceCctvIsInstalled(true)
+			.toiletRegistDiaperChangingTableIsAvailable(true)
+			.toiletRegistDiaperChangingTableLocation("여자화장실 입구")
+			.toiletRegistMaleToiletsNumber(5)
+			.toiletRegistMaleUrinalsNumber(10)
+			.toiletRegistMaleDisabledToiletsNumber(1)
+			.toiletRegistMaleDisabledUrinalsNumber(2)
+			.toiletRegistMaleChildToiletsNumber(1)
+			.toiletRegistMaleChildUrinalsNumber(2)
+			.toiletRegistFemaleToiletsNumber(8)
+			.toiletRegistFemaleDisabledToiletsNumber(2)
+			.toiletRegistFemaleChildToiletsNumber(2)
+			.userEmail("user@example.com")
+			.build();
+
+		doReturn(Optional.of(mockToiletRegist)).when(toiletRegistRepository).findBytoiletRegistId(1L);
+
+		// when
+		ToiletRegistResponse response = target.getToiletRegist(1L);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.toiletRegistId()).isEqualTo(1L);
+		assertThat(response.toiletRegistToiletName()).isEqualTo("서울역 화장실");
+		assertThat(response.toiletRegistRoadNameAddress()).isEqualTo("서울시 용산구 한강대로 405");
+		assertThat(response.toiletRegistNumberAddress()).isEqualTo("서울시 용산구 남대문로 20");
+		assertThat(response.toiletRegistLatitude()).isEqualTo(37.5551);
+		assertThat(response.toiletRegistLongitude()).isEqualTo(126.9707);
+		assertThat(response.toiletRegistManagementAgency()).isEqualTo("용산구청");
+		assertThat(response.toiletRegistPhoneNumber()).isEqualTo("02-123-4567");
+		assertThat(response.toiletRegistOpeningHours()).isEqualTo("24시간");
+		assertThat(response.toiletRegistOpeningHoursDetails()).isEqualTo("연중무휴");
+		assertThat(response.toiletRegistInstallationYearMonth()).isEqualTo("2020-05");
+		assertThat(response.toiletRegistOwnershipType()).isEqualTo("공공");
+		assertThat(response.toiletRegistWasteDisposalMethod()).isEqualTo("정화조");
+		assertThat(response.toiletInfoSafetyFacilityInstallationIsRequired()).isTrue();
+		assertThat(response.toiletRegistEmergencyBellIsInstalled()).isTrue();
+		assertThat(response.toiletRegistEmergencyBellLocation()).isEqualTo("남자화장실 입구");
+		assertThat(response.toiletRegistEntranceCctvIsInstalled()).isTrue();
+		assertThat(response.toiletRegistDiaperChangingTableIsAvailable()).isTrue();
+		assertThat(response.toiletRegistDiaperChangingTableLocation()).isEqualTo("여자화장실 입구");
+		assertThat(response.toiletRegistMaleToiletsNumber()).isEqualTo(5);
+		assertThat(response.toiletRegistMaleUrinalsNumber()).isEqualTo(10);
+		assertThat(response.toiletRegistMaleDisabledToiletsNumber()).isEqualTo(1);
+		assertThat(response.toiletRegistMaleDisabledUrinalsNumber()).isEqualTo(2);
+		assertThat(response.toiletRegistMaleChildToiletsNumber()).isEqualTo(1);
+		assertThat(response.toiletRegistMaleChildUrinalsNumber()).isEqualTo(2);
+		assertThat(response.toiletRegistFemaleToiletsNumber()).isEqualTo(8);
+		assertThat(response.toiletRegistFemaleDisabledToiletsNumber()).isEqualTo(2);
+		assertThat(response.toiletRegistFemaleChildToiletsNumber()).isEqualTo(2);
+		assertThat(response.userEmail()).isEqualTo("user@example.com");
+	}
+
+	@Test
+	public void 화장실등록조회실패_등록된화장실없음() {
+		// given
+		doReturn(Optional.empty()).when(toiletRegistRepository).findBytoiletRegistId(1L);
+
+		// when
+		ToiletRegistException exception = assertThrows(ToiletRegistException.class, () -> {
+			target.getToiletRegist(1L);
+		});
+
+		// then
+		assertThat(exception).isNotNull();
+		assertThat(exception.getErrorResult()).isEqualTo(ToiletRegistErrorResult.ENTITY_NOT_FOUND);
 	}
 
 	private ToiletRegistApproveRequest requestReject(){


### PR DESCRIPTION
## #️⃣연관된 이슈
- #38 

## 📝작업 내용
- 특정 화장실 등록 정보 조회 기능 구현
- 전체 화장실 등록 정보 조회 기능 구현
- 10개씩 Paging 처리
- toiletRegistConfirmedDate null일때 가장 먼저 조회 구현

### 📷스크린샷 (선택)



## 💬리뷰 요구사항(선택)
<img width="799" alt="image" src="https://github.com/user-attachments/assets/ed01aa4b-bfd6-4698-b8f5-6afbe0075d3f">

- OrderBy 추가 하였지만 ToiletRegistApproveServiceImplTests.java 쪽 정렬 테스트가 통과가 안됩니다. 확인 한번만 부탁드리겠습니다!